### PR TITLE
Fixed: Can not auto fill email address in IE11 #6

### DIFF
--- a/Kernel/Modules/AgentTicketPhoneCTI.pm
+++ b/Kernel/Modules/AgentTicketPhoneCTI.pm
@@ -134,6 +134,7 @@ sub Run {
 
             $Counter++;
 
+            $UserName = $LayoutObject->LinkEncode($UserName);
             $Screen .= ";CustomerKey_$Counter=$CustomerUserID;CustomerTicketText_$Counter=$UserName";
 
             next CUSTOMER if !$MaxUsers;


### PR DESCRIPTION
issue: $UserName is Chinese
e.g.: CustomerTicketText_1="Never%20文浩坚"%20never@znuny.cn;

fix: Encode URL
